### PR TITLE
Fixes 웹사이트 데모가 동작하지 않습니다

### DIFF
--- a/website/src/pages/demo.tsx
+++ b/website/src/pages/demo.tsx
@@ -29,7 +29,7 @@ function Demo() {
   const showViewer = useCallback((file: File) => {
     const reader = new FileReader()
 
-    reader.onload = (result) => {
+    reader.onloadend = (result) => {
       const bstr = result.target?.result
 
       if (bstr) {


### PR DESCRIPTION
`readAsBinaryString(file)` 은 `FileReader.readyState` 가 DONE 이 된 이후 읽을 수 있으며
`loadend` 이벤트 이후에 보장됩니다.
