### PR TITLE
Add signature "HWP Document File" in header

### DIFF
--- a/src/models/header.ts
+++ b/src/models/header.ts
@@ -22,8 +22,11 @@ import HWPVersion from './version'
 class HWPHeader {
   version: HWPVersion
 
-  constructor(version: HWPVersion) {
+  signature: string
+
+  constructor(version: HWPVersion, signature: string) {
     this.version = version
+    this.signature = signature
   }
 }
 

--- a/src/parser/__tests__/parse.test.ts
+++ b/src/parser/__tests__/parse.test.ts
@@ -43,4 +43,8 @@ describe.skip('parse', () => {
     expect(hwpDocument.sections[0].width).toBe(59528)
     expect(hwpDocument.sections[0].height).toBe(84188)
   })
+
+  it('should parse signature', () => {
+    expect(hwpDocument.header.signature).toBe('HWP Document File')
+  })
 })

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -35,6 +35,7 @@ import SectionParser from './SectionParser'
 const FILE_HEADER_BYTES = 256
 
 const SUPPORTED_VERSION = new HWPVersion(5, 1, 0, 0)
+const SIGNATURE = 'HWP Document File'
 
 function parseFileHeader(container: CFB$Container): HWPHeader {
   const fileHeader = find(container, 'FileHeader')
@@ -50,6 +51,9 @@ function parseFileHeader(container: CFB$Container): HWPHeader {
   }
 
   const signature = String.fromCharCode(...Array.from(content.slice(0, 17)))
+  if (SIGNATURE !== signature) {
+    throw new Error(`hwp file's signature should be ${SIGNATURE}. Received version: ${signature}`)
+  }
 
   const [major, minor, build, revision] = Array.from(content.slice(32, 36)).reverse()
   const version = new HWPVersion(major, minor, build, revision)

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -49,7 +49,7 @@ function parseFileHeader(container: CFB$Container): HWPHeader {
     throw new Error(`FileHeader must be ${FILE_HEADER_BYTES} bytes, Received: ${content.length}`)
   }
 
-  // TODO: (@hahnlee) 파일 시그니처 검증하기
+  const signature = String.fromCharCode(...Array.from(content.slice(0, 17)))
 
   const [major, minor, build, revision] = Array.from(content.slice(32, 36)).reverse()
   const version = new HWPVersion(major, minor, build, revision)
@@ -58,7 +58,7 @@ function parseFileHeader(container: CFB$Container): HWPHeader {
     throw new Error(`hwp.js only support ${SUPPORTED_VERSION} format. Received version: ${version}`)
   }
 
-  return new HWPHeader(version)
+  return new HWPHeader(version, signature)
 }
 
 function parseDocInfo(container: CFB$Container): DocInfo {

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -70,7 +70,7 @@ const TEXT_ALIGN: { [key: number]: string } = {
 
 class HWPViewer {
   private hwpDocument: HWPDocument = new HWPDocument(
-    new HWPHeader(new HWPVersion(5, 0, 0, 0)),
+    new HWPHeader(new HWPVersion(5, 0, 0, 0), 'HWP Document File'),
     new DocInfo(),
     [],
   )


### PR DESCRIPTION
I add signature property in class HWPHeader in header.ts
And add to its constructor, read when document parsing.

Cause I don't know whether you want to store signature or just throw an error and stop parsing immediately,
I just choose the first choice. I think it's better because we can make a feature that fixes the file signature in later.

Thx!