### PR TITLE
Fix for bug that page number doesn't change on some screen ratio

### DIFF
--- a/src/viewer/header.ts
+++ b/src/viewer/header.ts
@@ -44,7 +44,7 @@ class Header {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           if (entry.target.parentElement) {
-            const page = entry.target.parentElement.getAttribute('data-page-number')
+            const page = entry.target.getAttribute('data-page-number')
             const pageNumber = Number(page) + 1
             this.updatePageNumber(pageNumber)
           }

--- a/src/viewer/header.ts
+++ b/src/viewer/header.ts
@@ -43,18 +43,21 @@ class Header {
     this.observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          const page = entry.target.getAttribute('data-page-number')
-          const pageNumber = Number(page) + 1
-          this.updatePageNumber(pageNumber)
+          if (entry.target.parentElement) {
+            const page = entry.target.parentElement.getAttribute('data-page-number')
+            const pageNumber = Number(page) + 1
+            this.updatePageNumber(pageNumber)
+          }
         }
       })
     }, {
       root: this.content,
       rootMargin: '0px',
-      threshold: 0.5,
     })
 
-    this.pages.forEach((page) => this.observer.observe(page))
+    this.pages.forEach((page) => {
+      this.observer.observe(<Element>page.querySelector('.--hwpjs-observer'))
+    })
 
     this.draw()
   }

--- a/src/viewer/header.ts
+++ b/src/viewer/header.ts
@@ -43,7 +43,7 @@ class Header {
     this.observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          if (entry.target.parentElement) {
+          if (entry.isIntersecting && entry.target.parentElement) {
             const page = entry.target.getAttribute('data-page-number')
             const pageNumber = Number(page) + 1
             this.updatePageNumber(pageNumber)

--- a/src/viewer/header.ts
+++ b/src/viewer/header.ts
@@ -56,7 +56,7 @@ class Header {
     })
 
     this.pages.forEach((page) => {
-      this.observer.observe(<Element>page.querySelector('.--hwpjs-observer'))
+      this.observer.observe(<Element>page.querySelector('.hwpjs-observer'))
     })
 
     this.draw()

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -120,7 +120,7 @@ class HWPViewer {
     observer.style.width = '100%'
     observer.style.top = '50%'
     observer.style.left = '0'
-    observer.classList.add('--hwpjs-observer')
+    observer.classList.add('hwpjs-observer')
     observer.setAttribute('data-page-number', index.toString())
     page.appendChild(observer)
 

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -121,6 +121,7 @@ class HWPViewer {
     observer.style.top = '50%'
     observer.style.left = '0'
     observer.classList.add('--hwpjs-observer')
+    observer.setAttribute('data-page-number', index.toString())
     page.appendChild(observer)
 
     this.pages.push(page)

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -114,6 +114,15 @@ class HWPViewer {
 
     page.setAttribute('data-page-number', index.toString())
 
+    const observer = document.createElement('div')
+    observer.style.height = '2px'
+    observer.style.position = 'absolute'
+    observer.style.width = '100%'
+    observer.style.top = '50%'
+    observer.style.left = '0'
+    observer.classList.add('--hwpjs-observer')
+    page.appendChild(observer)
+
     this.pages.push(page)
 
     return page


### PR DESCRIPTION
When updating a page in the header, you used threshold, which makes it impossible for certain screen proportions to populate the screen by more than 50% of a page, resulting in a bug where the page indicator is not updated. To solve this bug, I inserted a div that was invisible at 50 percent of each page to observe that div.