### PR TITLE
[Feature] parse DocInfo -> DocumentProperties Record

### DIFF
--- a/src/models/caratLocation.ts
+++ b/src/models/caratLocation.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright Han Lee <hanlee.dev@gmail.com> and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class CaratLocation {
+  listId : number = 0
+
+  paragraphId: number = 0
+
+  // 문단 내에서의 글자 단위 위치
+  charIndex: number = 0
+}
+
+export default CaratLocation

--- a/src/models/docInfo.ts
+++ b/src/models/docInfo.ts
@@ -19,6 +19,7 @@ import FontFace from './fontFace'
 import BinData from './binData'
 import BorderFill from './borderFill'
 import ParagraphShape from './paragraphShape'
+import CaratLocation from './caratLocation'
 
 class DocInfo {
   sectionSize: number = 0
@@ -32,6 +33,20 @@ class DocInfo {
   borderFills: BorderFill[] = []
 
   paragraphShapes: ParagraphShape[] = []
+
+  startingPageIndex: number = 0
+
+  startingFootnoteIndex: number = 0
+
+  startingEndnoteIndex: number = 0
+
+  startingPictureIndex: number = 0
+
+  startingTableIndex: number = 0
+
+  startingEquationIndex: number = 0
+
+  caratLocation: CaratLocation = new CaratLocation()
 
   getCharShpe(index: number): CharShape | undefined {
     return this.charShapes[index]

--- a/src/parser/DocInfoParser.ts
+++ b/src/parser/DocInfoParser.ts
@@ -47,7 +47,7 @@ class DocInfoParser {
     const reader = new ByteReader(record.payload)
     this.result.sectionSize = reader.readUInt16()
 
-    // TODO: (@hahnlee) 다른 프로퍼티도 구현하기
+    // TODO: (@sboh1214) 다른 프로퍼티도 구현하기
   }
 
   visitCharShape(record: HWPRecord) {

--- a/src/parser/DocInfoParser.ts
+++ b/src/parser/DocInfoParser.ts
@@ -43,11 +43,20 @@ class DocInfoParser {
     this.container = container
   }
 
-  visitDocumentPropertes(record: HWPRecord) {
+  visitDocumentProperties(record: HWPRecord) {
     const reader = new ByteReader(record.payload)
     this.result.sectionSize = reader.readUInt16()
 
-    // TODO: (@sboh1214) 다른 프로퍼티도 구현하기
+    this.result.startingPageIndex = reader.readUInt16()
+    this.result.startingFootnoteIndex = reader.readUInt16()
+    this.result.startingEndnoteIndex = reader.readUInt16()
+    this.result.startingPictureIndex = reader.readUInt16()
+    this.result.startingTableIndex = reader.readUInt16()
+    this.result.startingEquationIndex = reader.readUInt16()
+
+    this.result.caratLocation.listId = reader.readUInt32()
+    this.result.caratLocation.paragraphId = reader.readUInt32()
+    this.result.caratLocation.charIndex = reader.readUInt32()
   }
 
   visitCharShape(record: HWPRecord) {
@@ -218,7 +227,7 @@ class DocInfoParser {
   private visit = (record: HWPRecord) => {
     switch (record.tagID) {
       case DocInfoTagID.HWPTAG_DOCUMENT_PROPERTIES: {
-        this.visitDocumentPropertes(record)
+        this.visitDocumentProperties(record)
         break
       }
 


### PR DESCRIPTION
I am currently working at parsing DocInfo -> DocumentProperties Record
class DocInfo's property and the constructor will be affected by this pull request.
Also, there is typo [visitDocumentPropertes in DocInfoParser](https://github.com/hahnlee/hwp.js/blob/a664a9ab7c05281d6f509ab80d2dac1e5431a367/src/parser/DocInfoParser.ts#L46)
I'll fix it too.  :)