### PR TITLE
Parse CaratLocation and StartingIndex in DocInfo

### DIFF
--- a/src/models/caratLocation.ts
+++ b/src/models/caratLocation.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright Han Lee <hanlee.dev@gmail.com> and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class CaratLocation {
+  listId : number = 0
+
+  paragraphId: number = 0
+
+  // 문단 내에서의 글자 단위 위치
+  charIndex: number = 0
+}
+
+export default CaratLocation

--- a/src/models/docInfo.ts
+++ b/src/models/docInfo.ts
@@ -19,6 +19,8 @@ import FontFace from './fontFace'
 import BinData from './binData'
 import BorderFill from './borderFill'
 import ParagraphShape from './paragraphShape'
+import StartingIndex from './startingIndex'
+import CaratLocation from './caratLocation'
 
 class DocInfo {
   sectionSize: number = 0
@@ -32,6 +34,10 @@ class DocInfo {
   borderFills: BorderFill[] = []
 
   paragraphShapes: ParagraphShape[] = []
+
+  startingIndex: StartingIndex = new StartingIndex()
+
+  caratLocation: CaratLocation = new CaratLocation()
 
   getCharShpe(index: number): CharShape | undefined {
     return this.charShapes[index]

--- a/src/models/startingIndex.ts
+++ b/src/models/startingIndex.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright Han Lee <hanlee.dev@gmail.com> and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class StartingIndex {
+  page: number = 0
+
+  footnote: number = 0
+
+  endnote: number =0
+
+  picture: number=0
+
+  table: number=0
+
+  equation: number=0
+}
+
+export default StartingIndex

--- a/src/parser/DocInfoParser.ts
+++ b/src/parser/DocInfoParser.ts
@@ -47,7 +47,16 @@ class DocInfoParser {
     const reader = new ByteReader(record.payload)
     this.result.sectionSize = reader.readUInt16()
 
-    // TODO: (@hahnlee) 다른 프로퍼티도 구현하기
+    this.result.startingIndex.page = reader.readUInt16()
+    this.result.startingIndex.footnote = reader.readUInt16()
+    this.result.startingIndex.endnote = reader.readUInt16()
+    this.result.startingIndex.picture = reader.readUInt16()
+    this.result.startingIndex.table = reader.readUInt16()
+    this.result.startingIndex.equation = reader.readUInt16()
+
+    this.result.caratLocation.listId = reader.readUInt32()
+    this.result.caratLocation.paragraphId = reader.readUInt32()
+    this.result.caratLocation.charIndex = reader.readUInt32()
   }
 
   visitCharShape(record: HWPRecord) {


### PR DESCRIPTION
DocInfo parser에서 TODO로 작성하신 나머지 정보를 파싱하였습니다.
models 안에 CaratLocation 과 StartingIndex 클래스 파일을 추가하였습니다.
감사합니다!