### PR TITLE
Parse PageDef in SectionParser

### DIFF
--- a/src/models/section.ts
+++ b/src/models/section.ts
@@ -34,6 +34,10 @@ class Section {
   footerPadding: number = 0
 
   content: Paragraph[] = []
+
+  orientation: number = 0
+
+  bookBindingMethod: number = 0
 }
 
 export default Section

--- a/src/parser/SectionParser.ts
+++ b/src/parser/SectionParser.ts
@@ -32,6 +32,7 @@ import RecordReader from '../utils/recordReader'
 import { isTable, isShape } from '../utils/controlUtil'
 import parseRecord from './parseRecord'
 import { PictureControl } from '../models/controls/shapes'
+import { getBitValue } from '../utils/bitUtils'
 
 class SectionParser {
   private record: HWPRecord
@@ -56,7 +57,9 @@ class SectionParser {
     this.result.headerPadding = reader.readUInt32()
     this.result.footerPadding = reader.readUInt32()
 
-    // TODO: (@hahnlee) 속성정보도 파싱하기
+    const property = reader.readUInt32()
+    this.result.orientation = getBitValue(property, 0, 0)
+    this.result.bookBindingMethod = getBitValue(property, 1, 2)
   }
 
   // TODO: (@hahnlee) mapper 패턴 사용하기


### PR DESCRIPTION
> 한글 문서 파일 구조 5.0 revision 1.3:20181108 의 내용을 일부 발췌하였습니다.

## 4.3.10.1.1 용지 설정

Tag ID : HWPTAG_PAGE_DEF

| bit 0 | 용지방향 |
|-----|---------|
| 0 | 좁게 |
| 1 | 넓게 |

| bit 1~2 | 제책 방법 |
|-----|---------|
| 0 | 한쪽 편집 |
| 1 | 맞쪽 편집 |
| 2 | 위로 넘기기 |