### PR TITLE
Parse Layout Compatibility, Compatible Document

### DIFF
--- a/src/models/docInfo.ts
+++ b/src/models/docInfo.ts
@@ -21,6 +21,7 @@ import BorderFill from './borderFill'
 import ParagraphShape from './paragraphShape'
 import StartingIndex from './startingIndex'
 import CaratLocation from './caratLocation'
+import LayoutCompatibility from './layoutCompatibility'
 
 class DocInfo {
   sectionSize: number = 0
@@ -38,6 +39,10 @@ class DocInfo {
   startingIndex: StartingIndex = new StartingIndex()
 
   caratLocation: CaratLocation = new CaratLocation()
+
+  compatibleDocument: number = 0
+
+  layoutCompatiblity: LayoutCompatibility = new LayoutCompatibility()
 
   getCharShpe(index: number): CharShape | undefined {
     return this.charShapes[index]

--- a/src/models/layoutCompatibility.ts
+++ b/src/models/layoutCompatibility.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright Han Lee <hanlee.dev@gmail.com> and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class LayoutCompatibility {
+  char: number = 0
+
+  paragraph: number = 0
+
+  section: number = 0
+
+  object: number = 0
+
+  field: number = 0
+}
+
+export default LayoutCompatibility

--- a/src/parser/DocInfoParser.ts
+++ b/src/parser/DocInfoParser.ts
@@ -224,6 +224,20 @@ class DocInfoParser {
     this.result.paragraphShapes.push(shape)
   }
 
+  visitCompatibleDocument(record: HWPRecord) {
+    const reader = new ByteReader(record.payload)
+    this.result.compatibleDocument = reader.readUInt32()
+  }
+
+  visitLayoutCompatibility(record: HWPRecord) {
+    const reader = new ByteReader(record.payload)
+    this.result.layoutCompatiblity.char = reader.readUInt32()
+    this.result.layoutCompatiblity.paragraph = reader.readUInt32()
+    this.result.layoutCompatiblity.section = reader.readUInt32()
+    this.result.layoutCompatiblity.object = reader.readUInt32()
+    this.result.layoutCompatiblity.field = reader.readUInt32()
+  }
+
   private visit = (record: HWPRecord) => {
     switch (record.tagID) {
       case DocInfoTagID.HWPTAG_DOCUMENT_PROPERTIES: {
@@ -253,6 +267,16 @@ class DocInfoParser {
 
       case DocInfoTagID.HWPTAG_PARA_SHAPE: {
         this.visitParagraphShape(record)
+        break
+      }
+
+      case DocInfoTagID.HWPTAG_COMPATIBLE_DOCUMENT: {
+        this.visitCompatibleDocument(record)
+        break
+      }
+
+      case DocInfoTagID.HWPTAG_LAYOUT_COMPATIBILITY: {
+        this.visitLayoutCompatibility(record)
         break
       }
 


### PR DESCRIPTION
> 한글 문서 파일 구조 5.0 revision 1.3:20181108 의 내용을 일부 발췌하였습니다.

DocInfo -> HWPTAG_COMPATIBLE_DOCUMENT, HWPTAG_LAYOUT_COMPATIBILITY

<img width="718" alt="스크린샷 2020-10-04 오후 9 21 50" src="https://user-images.githubusercontent.com/30364442/95015400-a09e1b80-0687-11eb-812b-8bbda2187dc1.png">
